### PR TITLE
Fix transform string bug

### DIFF
--- a/src/components/FrameHeading.tsx
+++ b/src/components/FrameHeading.tsx
@@ -106,7 +106,7 @@ export function FrameHeading({
 					labelSide === 'top' || labelSide === 'bottom' ? Math.ceil(width) : Math.ceil(height)
 				}px + var(--space-5))`,
 				bottom: '100%',
-				transform: `${labelTranslate} scale(var(--tl-scale)) translateX(calc(-1 * var(--space-3))`,
+                                transform: `${labelTranslate} scale(var(--tl-scale)) translateX(calc(-1 * var(--space-3)))`,
 			}}
 			onPointerDown={handlePointerDown}
 		>


### PR DESCRIPTION
## Summary
- fix incorrect `translateX` style string in `FrameHeading`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684001432fec83299733cecade764302