### PR TITLE
Add table shape tool with adjustable rows and columns

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,8 @@
 'use client'
 
 import { LiveImageShape, LiveImageShapeUtil } from '@/components/LiveImageShapeUtil'
+import { TableShapeUtil } from '@/components/TableShapeUtil'
+import { TableTool } from '@/components/TableTool'
 import { LockupLink } from '@/components/LockupLink'
 import { LiveImageProvider } from '@/hooks/useLiveImage'
 import * as fal from '@fal-ai/serverless-client'
@@ -26,35 +28,46 @@ fal.config({
 })
 
 const overrides: TLUiOverrides = {
-	tools(editor, tools) {
-		tools.liveImage = {
-			id: 'live-image',
-			icon: 'tool-frame',
-			label: 'Frame',
-			kbd: 'f',
-			readonlyOk: false,
-			onSelect: () => {
-				editor.setCurrentTool('live-image')
-			},
-		}
-		return tools
-	},
-	toolbar(_app, toolbar, { tools }) {
-		const frameIndex = toolbar.findIndex((item) => item.id === 'frame')
-		if (frameIndex !== -1) toolbar.splice(frameIndex, 1)
+        tools(editor, tools) {
+                tools.liveImage = {
+                        id: 'live-image',
+                        icon: 'tool-frame',
+                        label: 'Frame',
+                        kbd: 'f',
+                        readonlyOk: false,
+                        onSelect: () => {
+                                editor.setCurrentTool('live-image')
+                        },
+                }
+                tools.table = {
+                        id: 'table',
+                        icon: 'layout-grid',
+                        label: 'Table',
+                        kbd: 't',
+                        readonlyOk: true,
+                        onSelect: () => {
+                                editor.setCurrentTool('table')
+                        },
+                }
+                return tools
+        },
+        toolbar(_app, toolbar, { tools }) {
+                const frameIndex = toolbar.findIndex((item) => item.id === 'frame')
+                if (frameIndex !== -1) toolbar.splice(frameIndex, 1)
 		const highlighterIndex = toolbar.findIndex((item) => item.id === 'highlight')
-		if (highlighterIndex !== -1) {
-			const highlighterItem = toolbar[highlighterIndex]
-			toolbar.splice(highlighterIndex, 1)
-			toolbar.splice(3, 0, highlighterItem)
-		}
-		toolbar.splice(2, 0, toolbarItem(tools.liveImage))
-		return toolbar
-	},
+                if (highlighterIndex !== -1) {
+                        const highlighterItem = toolbar[highlighterIndex]
+                        toolbar.splice(highlighterIndex, 1)
+                        toolbar.splice(3, 0, highlighterItem)
+                }
+                toolbar.splice(2, 0, toolbarItem(tools.liveImage))
+                toolbar.splice(3, 0, toolbarItem(tools.table))
+                return toolbar
+        },
 }
 
-const shapeUtils = [LiveImageShapeUtil]
-const tools = [LiveImageTool]
+const shapeUtils = [LiveImageShapeUtil, TableShapeUtil]
+const tools = [LiveImageTool, TableTool]
 
 export default function Home() {
 	const onEditorMount = (editor: Editor) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,7 +41,7 @@ const overrides: TLUiOverrides = {
                 }
                 tools.table = {
                         id: 'table',
-                        icon: 'layout-grid',
+                        icon: 'stack-vertical',
                         label: 'Table',
                         kbd: 't',
                         readonlyOk: true,

--- a/src/components/TableShapeUtil.tsx
+++ b/src/components/TableShapeUtil.tsx
@@ -60,115 +60,104 @@ export class TableShapeUtil extends ShapeUtil<TableShape> {
     const editor = useEditor()
     const bounds = this.editor.getShapeGeometry(shape).bounds
     const { rows, cols } = shape.props
-    const rowHeight = bounds.height / rows
-    const colWidth = bounds.width / cols
+
+    const inputs = []
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        inputs.push(
+          <input
+            key={`${r}-${c}`}
+            style={{
+              width: '100%',
+              height: '100%',
+              border: '1px solid currentColor',
+              boxSizing: 'border-box',
+            }}
+          />
+        )
+      }
+    }
 
     return (
       <>
         <SVGContainer>
-          <rect
-            width={bounds.width}
-            height={bounds.height}
-            fill="none"
-            stroke="currentColor"
-          />
-          {Array.from({ length: rows - 1 }).map((_, i) => (
-            <line
-              key={`r${i}`}
-              x1={0}
-              x2={bounds.width}
-              y1={(i + 1) * rowHeight}
-              y2={(i + 1) * rowHeight}
-              stroke="currentColor"
-            />
-          ))}
-          {Array.from({ length: cols - 1 }).map((_, i) => (
-            <line
-              key={`c${i}`}
-              y1={0}
-              y2={bounds.height}
-              x1={(i + 1) * colWidth}
-              x2={(i + 1) * colWidth}
-              stroke="currentColor"
-            />
-          ))}
+          <foreignObject width={bounds.width} height={bounds.height}>
+            <div
+              style={{
+                display: 'grid',
+                width: '100%',
+                height: '100%',
+                gridTemplateRows: `repeat(${rows}, 1fr)`,
+                gridTemplateColumns: `repeat(${cols}, 1fr)`,
+              }}
+            >
+              {inputs}
+            </div>
+          </foreignObject>
         </SVGContainer>
-        <Button
-          type="icon"
-          icon="minus"
+        <div
           style={{
             position: 'absolute',
-            top: -4,
-            left: bounds.width,
+            top: -28,
+            left: 0,
+            display: 'flex',
+            gap: 8,
             pointerEvents: 'auto',
             transform: 'scale(var(--tl-scale))',
           }}
           onPointerDown={(e) => e.stopPropagation()}
-          onClick={() =>
-            editor.updateShape<TableShape>({
-              id: shape.id,
-              type: 'table',
-              props: { cols: Math.max(1, cols - 1) },
-            })
-          }
-        />
-        <Button
-          type="icon"
-          icon="plus"
-          style={{
-            position: 'absolute',
-            top: -4,
-            left: bounds.width + 24,
-            pointerEvents: 'auto',
-            transform: 'scale(var(--tl-scale))',
-          }}
-          onPointerDown={(e) => e.stopPropagation()}
-          onClick={() =>
-            editor.updateShape<TableShape>({
-              id: shape.id,
-              type: 'table',
-              props: { cols: cols + 1 },
-            })
-          }
-        />
-        <Button
-          type="icon"
-          icon="minus"
-          style={{
-            position: 'absolute',
-            top: bounds.height,
-            left: -4,
-            pointerEvents: 'auto',
-            transform: 'scale(var(--tl-scale))',
-          }}
-          onPointerDown={(e) => e.stopPropagation()}
-          onClick={() =>
-            editor.updateShape<TableShape>({
-              id: shape.id,
-              type: 'table',
-              props: { rows: Math.max(1, rows - 1) },
-            })
-          }
-        />
-        <Button
-          type="icon"
-          icon="plus"
-          style={{
-            position: 'absolute',
-            top: bounds.height + 24,
-            left: -4,
-            pointerEvents: 'auto',
-            transform: 'scale(var(--tl-scale))',
-          }}
-          onPointerDown={(e) => e.stopPropagation()}
-          onClick={() =>
-            editor.updateShape<TableShape>({
-              id: shape.id,
-              type: 'table',
-              props: { rows: rows + 1 },
-            })
-          }
-        />
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <Button
+              type="icon"
+              icon="minus"
+              onClick={() =>
+                editor.updateShape<TableShape>({
+                  id: shape.id,
+                  type: 'table',
+                  props: { rows: Math.max(1, rows - 1) },
+                })
+              }
+            />
+            <span style={{ fontSize: '12px' }}>{rows}</span>
+            <Button
+              type="icon"
+              icon="plus"
+              onClick={() =>
+                editor.updateShape<TableShape>({
+                  id: shape.id,
+                  type: 'table',
+                  props: { rows: rows + 1 },
+                })
+              }
+            />
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <Button
+              type="icon"
+              icon="minus"
+              onClick={() =>
+                editor.updateShape<TableShape>({
+                  id: shape.id,
+                  type: 'table',
+                  props: { cols: Math.max(1, cols - 1) },
+                })
+              }
+            />
+            <span style={{ fontSize: '12px' }}>{cols}</span>
+            <Button
+              type="icon"
+              icon="plus"
+              onClick={() =>
+                editor.updateShape<TableShape>({
+                  id: shape.id,
+                  type: 'table',
+                  props: { cols: cols + 1 },
+                })
+              }
+            />
+          </div>
+        </div>
       </>
     )
   }

--- a/src/components/TableShapeUtil.tsx
+++ b/src/components/TableShapeUtil.tsx
@@ -1,0 +1,175 @@
+import {
+  Button,
+  Geometry2d,
+  Rectangle2d,
+  ShapeUtil,
+  SVGContainer,
+  TLBaseShape,
+  TLOnResizeHandler,
+  resizeBox,
+  toDomPrecision,
+  useEditor,
+} from '@tldraw/tldraw'
+
+export type TableShape = TLBaseShape<
+  'table',
+  {
+    w: number
+    h: number
+    rows: number
+    cols: number
+  }
+>
+
+export class TableShapeUtil extends ShapeUtil<TableShape> {
+  static type = 'table' as const
+
+  override canEdit = () => true
+  override isAspectRatioLocked = () => false
+
+  getDefaultProps() {
+    return {
+      w: 300,
+      h: 200,
+      rows: 2,
+      cols: 2,
+    }
+  }
+
+  override getGeometry(shape: TableShape): Geometry2d {
+    return new Rectangle2d({ width: shape.props.w, height: shape.props.h, isFilled: false })
+  }
+
+  override onResize: TLOnResizeHandler<TableShape> = (shape, info) => {
+    return resizeBox(shape, info)
+  }
+
+  indicator(shape: TableShape) {
+    const bounds = this.editor.getShapeGeometry(shape).bounds
+    return (
+      <rect
+        width={toDomPrecision(bounds.width)}
+        height={toDomPrecision(bounds.height)}
+        className="tl-frame-indicator"
+      />
+    )
+  }
+
+  override component(shape: TableShape) {
+    const editor = useEditor()
+    const bounds = this.editor.getShapeGeometry(shape).bounds
+    const { rows, cols } = shape.props
+    const rowHeight = bounds.height / rows
+    const colWidth = bounds.width / cols
+
+    return (
+      <>
+        <SVGContainer>
+          <rect
+            width={bounds.width}
+            height={bounds.height}
+            fill="none"
+            stroke="currentColor"
+          />
+          {Array.from({ length: rows - 1 }).map((_, i) => (
+            <line
+              key={`r${i}`}
+              x1={0}
+              x2={bounds.width}
+              y1={(i + 1) * rowHeight}
+              y2={(i + 1) * rowHeight}
+              stroke="currentColor"
+            />
+          ))}
+          {Array.from({ length: cols - 1 }).map((_, i) => (
+            <line
+              key={`c${i}`}
+              y1={0}
+              y2={bounds.height}
+              x1={(i + 1) * colWidth}
+              x2={(i + 1) * colWidth}
+              stroke="currentColor"
+            />
+          ))}
+        </SVGContainer>
+        <Button
+          type="icon"
+          icon="minus"
+          style={{
+            position: 'absolute',
+            top: -4,
+            left: bounds.width,
+            pointerEvents: 'auto',
+            transform: 'scale(var(--tl-scale))',
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={() =>
+            editor.updateShape<TableShape>({
+              id: shape.id,
+              type: 'table',
+              props: { cols: Math.max(1, cols - 1) },
+            })
+          }
+        />
+        <Button
+          type="icon"
+          icon="plus"
+          style={{
+            position: 'absolute',
+            top: -4,
+            left: bounds.width + 24,
+            pointerEvents: 'auto',
+            transform: 'scale(var(--tl-scale))',
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={() =>
+            editor.updateShape<TableShape>({
+              id: shape.id,
+              type: 'table',
+              props: { cols: cols + 1 },
+            })
+          }
+        />
+        <Button
+          type="icon"
+          icon="minus"
+          style={{
+            position: 'absolute',
+            top: bounds.height,
+            left: -4,
+            pointerEvents: 'auto',
+            transform: 'scale(var(--tl-scale))',
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={() =>
+            editor.updateShape<TableShape>({
+              id: shape.id,
+              type: 'table',
+              props: { rows: Math.max(1, rows - 1) },
+            })
+          }
+        />
+        <Button
+          type="icon"
+          icon="plus"
+          style={{
+            position: 'absolute',
+            top: bounds.height + 24,
+            left: -4,
+            pointerEvents: 'auto',
+            transform: 'scale(var(--tl-scale))',
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={() =>
+            editor.updateShape<TableShape>({
+              id: shape.id,
+              type: 'table',
+              props: { rows: rows + 1 },
+            })
+          }
+        />
+      </>
+    )
+  }
+}
+

--- a/src/components/TableShapeUtil.tsx
+++ b/src/components/TableShapeUtil.tsx
@@ -11,6 +11,7 @@ import {
   toDomPrecision,
   useEditor,
 } from '@tldraw/tldraw'
+import { useState } from 'react'
 
 export type TableShape = TLBaseShape<
   'table',
@@ -60,6 +61,7 @@ export class TableShapeUtil extends ShapeUtil<TableShape> {
     const editor = useEditor()
     const bounds = this.editor.getShapeGeometry(shape).bounds
     const { rows, cols } = shape.props
+    const [open, setOpen] = useState(false)
 
     const inputs = []
     for (let r = 0; r < rows; r++) {
@@ -67,6 +69,7 @@ export class TableShapeUtil extends ShapeUtil<TableShape> {
         inputs.push(
           <input
             key={`${r}-${c}`}
+            type="text"
             style={{
               width: '100%',
               height: '100%',
@@ -78,9 +81,52 @@ export class TableShapeUtil extends ShapeUtil<TableShape> {
       }
     }
 
+    const gridLines = []
+    for (let r = 1; r < rows; r++) {
+      const y = (bounds.height * r) / rows
+      gridLines.push(
+        <line
+          key={`row-${r}`}
+          x1={0}
+          y1={y}
+          x2={bounds.width}
+          y2={y}
+          className="tl-frame__body"
+          pointerEvents="none"
+        />
+      )
+    }
+    for (let c = 1; c < cols; c++) {
+      const x = (bounds.width * c) / cols
+      gridLines.push(
+        <line
+          key={`col-${c}`}
+          x1={x}
+          y1={0}
+          x2={x}
+          y2={bounds.height}
+          className="tl-frame__body"
+          pointerEvents="none"
+        />
+      )
+    }
+
     return (
       <>
         <SVGContainer>
+          <svg
+            width={bounds.width}
+            height={bounds.height}
+            style={{ position: 'absolute', top: 0, left: 0 }}
+          >
+            <rect
+              width={bounds.width}
+              height={bounds.height}
+              className="tl-frame__body"
+              fill="none"
+            />
+            {gridLines}
+          </svg>
           <foreignObject width={bounds.width} height={bounds.height}>
             <div
               style={{
@@ -95,69 +141,87 @@ export class TableShapeUtil extends ShapeUtil<TableShape> {
             </div>
           </foreignObject>
         </SVGContainer>
-        <div
+        <Button
+          type="icon"
+          icon="gear"
           style={{
             position: 'absolute',
             top: -28,
             left: 0,
-            display: 'flex',
-            gap: 8,
             pointerEvents: 'auto',
             transform: 'scale(var(--tl-scale))',
           }}
           onPointerDown={(e) => e.stopPropagation()}
-        >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-            <Button
-              type="icon"
-              icon="minus"
-              onClick={() =>
-                editor.updateShape<TableShape>({
-                  id: shape.id,
-                  type: 'table',
-                  props: { rows: Math.max(1, rows - 1) },
-                })
-              }
-            />
-            <span style={{ fontSize: '12px' }}>{rows}</span>
-            <Button
-              type="icon"
-              icon="plus"
-              onClick={() =>
-                editor.updateShape<TableShape>({
-                  id: shape.id,
-                  type: 'table',
-                  props: { rows: rows + 1 },
-                })
-              }
-            />
+          onClick={() => setOpen(!open)}
+        />
+        {open && (
+          <div
+            style={{
+              position: 'absolute',
+              top: -28,
+              left: 28,
+              background: 'var(--color-panel)',
+              borderRadius: 4,
+              padding: 4,
+              display: 'flex',
+              gap: 8,
+              pointerEvents: 'auto',
+              transform: 'scale(var(--tl-scale))',
+            }}
+            onPointerDown={(e) => e.stopPropagation()}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <Button
+                type="icon"
+                icon="minus"
+                onClick={() =>
+                  editor.updateShape<TableShape>({
+                    id: shape.id,
+                    type: 'table',
+                    props: { rows: Math.max(1, rows - 1) },
+                  })
+                }
+              />
+              <span style={{ fontSize: '12px' }}>{rows}</span>
+              <Button
+                type="icon"
+                icon="plus"
+                onClick={() =>
+                  editor.updateShape<TableShape>({
+                    id: shape.id,
+                    type: 'table',
+                    props: { rows: rows + 1 },
+                  })
+                }
+              />
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <Button
+                type="icon"
+                icon="minus"
+                onClick={() =>
+                  editor.updateShape<TableShape>({
+                    id: shape.id,
+                    type: 'table',
+                    props: { cols: Math.max(1, cols - 1) },
+                  })
+                }
+              />
+              <span style={{ fontSize: '12px' }}>{cols}</span>
+              <Button
+                type="icon"
+                icon="plus"
+                onClick={() =>
+                  editor.updateShape<TableShape>({
+                    id: shape.id,
+                    type: 'table',
+                    props: { cols: cols + 1 },
+                  })
+                }
+              />
+            </div>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-            <Button
-              type="icon"
-              icon="minus"
-              onClick={() =>
-                editor.updateShape<TableShape>({
-                  id: shape.id,
-                  type: 'table',
-                  props: { cols: Math.max(1, cols - 1) },
-                })
-              }
-            />
-            <span style={{ fontSize: '12px' }}>{cols}</span>
-            <Button
-              type="icon"
-              icon="plus"
-              onClick={() =>
-                editor.updateShape<TableShape>({
-                  id: shape.id,
-                  type: 'table',
-                  props: { cols: cols + 1 },
-                })
-              }
-            />
-          </div>
-        </div>
+        )}
       </>
     )
   }

--- a/src/components/TableShapeUtil.tsx
+++ b/src/components/TableShapeUtil.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import {
   Button,
   Geometry2d,

--- a/src/components/TableShapeUtil.tsx
+++ b/src/components/TableShapeUtil.tsx
@@ -146,7 +146,7 @@ export class TableShapeUtil extends ShapeUtil<TableShape> {
           icon="gear"
           style={{
             position: 'absolute',
-            top: -28,
+            top: -32,
             left: 0,
             pointerEvents: 'auto',
             transform: 'scale(var(--tl-scale))',
@@ -158,19 +158,22 @@ export class TableShapeUtil extends ShapeUtil<TableShape> {
           <div
             style={{
               position: 'absolute',
-              top: -28,
+              top: -36,
               left: 28,
               background: 'var(--color-panel)',
+              boxShadow: 'var(--shadow-2)',
               borderRadius: 4,
-              padding: 4,
+              padding: '6px 8px',
               display: 'flex',
-              gap: 8,
+              flexDirection: 'column',
+              gap: 6,
               pointerEvents: 'auto',
               transform: 'scale(var(--tl-scale))',
             }}
             onPointerDown={(e) => e.stopPropagation()}
           >
-            <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <span style={{ fontSize: '12px', flexGrow: 1 }}>Rows</span>
               <Button
                 type="icon"
                 icon="minus"
@@ -182,7 +185,7 @@ export class TableShapeUtil extends ShapeUtil<TableShape> {
                   })
                 }
               />
-              <span style={{ fontSize: '12px' }}>{rows}</span>
+              <span style={{ fontSize: '12px', minWidth: '1.5em', textAlign: 'center' }}>{rows}</span>
               <Button
                 type="icon"
                 icon="plus"
@@ -196,6 +199,7 @@ export class TableShapeUtil extends ShapeUtil<TableShape> {
               />
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <span style={{ fontSize: '12px', flexGrow: 1 }}>Columns</span>
               <Button
                 type="icon"
                 icon="minus"
@@ -207,7 +211,7 @@ export class TableShapeUtil extends ShapeUtil<TableShape> {
                   })
                 }
               />
-              <span style={{ fontSize: '12px' }}>{cols}</span>
+              <span style={{ fontSize: '12px', minWidth: '1.5em', textAlign: 'center' }}>{cols}</span>
               <Button
                 type="icon"
                 icon="plus"

--- a/src/components/TableTool.tsx
+++ b/src/components/TableTool.tsx
@@ -1,0 +1,7 @@
+import { FrameShapeTool } from '@tldraw/tldraw'
+
+export class TableTool extends FrameShapeTool {
+  static override id = 'table'
+  static override initial = 'idle'
+  override shapeType = 'table'
+}


### PR DESCRIPTION
## Summary
- add new `TableShapeUtil` to render a grid with plus/minus buttons
- add `TableTool` for drawing tables
- register table tool and shape util in the tldraw overrides

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684002ef1f148329b13d9858c8f6a50c